### PR TITLE
feat: Telegram monitoring alerts on scraper failure (closes #27)

### DIFF
--- a/deploy-server.ps1
+++ b/deploy-server.ps1
@@ -1,0 +1,2 @@
+# Quick deploy to Hetzner - run after merging PRs
+ssh -i ~/.ssh/clawbothetnzer root@178.156.208.66 "cd /var/www/atis-line && git pull origin main && npm install --omit=dev && pm2 restart atis-line && echo 'Deployed!'"

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,19 @@
+server {
+    listen 80;
+    listen 443 ssl;
+    server_name atis.checkonmom.ca;
+
+    ssl_certificate /etc/letsencrypt/live/atis.checkonmom.ca/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/atis.checkonmom.ca/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:3341;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ const { scrapeAll, closeBrowser } = require('./src/data/aeroview');
 const { updateCache, getCache, getAudioUrl, AUDIO_DIR } = require('./src/audio/cache-manager');
 const { getRandomSignOff, getRandomJoke, ABOUT_TEXT } = require('./src/personality');
 const { humanizeAtis } = require('./src/speech/humanize');
+const { recordSuccess, recordFailure, checkAlerts } = require('./src/monitoring/alerter');
 
 const app = express();
 const port = process.env.PORT || 3338;
@@ -196,11 +197,15 @@ async function refreshAtisData() {
     if (result && result.raw) {
       const speechText = await humanizeAtis(result.raw, name);
       await updateCache(icao, speechText, result.letter);
+      recordSuccess(icao);
       console.log(`  ${icao}: information ${result.letter || '?'}`);
     } else {
+      recordFailure(icao, 'No data returned from scraper');
       console.log(`  ${icao}: no data`);
     }
   }
+
+  await checkAlerts();
 }
 
 // --- Graceful shutdown (PM2 sends SIGINT/SIGTERM on restart) ---

--- a/src/monitoring/alerter.js
+++ b/src/monitoring/alerter.js
@@ -1,0 +1,87 @@
+const ALERT_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
+const ALERT_COOLDOWN_MS = 30 * 60 * 1000; // 30 minutes between alerts per airport
+
+// Per-airport tracking: { lastSuccessTime, consecutiveFailures, lastAlertTime, lastError }
+const state = new Map();
+
+function getState(icao) {
+  if (!state.has(icao)) {
+    state.set(icao, {
+      lastSuccessTime: Date.now(),
+      consecutiveFailures: 0,
+      lastAlertTime: null,
+      lastError: null,
+    });
+  }
+  return state.get(icao);
+}
+
+function recordSuccess(icao) {
+  const s = getState(icao);
+  s.lastSuccessTime = Date.now();
+  s.consecutiveFailures = 0;
+  s.lastError = null;
+  s.lastAlertTime = null; // clear alert state on recovery
+}
+
+function recordFailure(icao, error) {
+  const s = getState(icao);
+  s.consecutiveFailures++;
+  s.lastError = error instanceof Error ? error.message : String(error || 'Unknown error');
+}
+
+async function sendTelegram(text) {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  const chatId = process.env.TELEGRAM_CHAT_ID;
+  if (!token || !chatId) return;
+
+  const url = `https://api.telegram.org/bot${token}/sendMessage`;
+  try {
+    await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: chatId, text }),
+    });
+  } catch (err) {
+    console.error(`[Telegram] Failed to send alert: ${err.message}`);
+  }
+}
+
+async function checkAlerts() {
+  const now = Date.now();
+  for (const [icao, s] of state) {
+    if (s.consecutiveFailures === 0) continue;
+
+    const failingDuration = now - s.lastSuccessTime;
+    if (failingDuration < ALERT_THRESHOLD_MS) continue;
+
+    // Cooldown: don't re-alert within 30 minutes
+    if (s.lastAlertTime && (now - s.lastAlertTime) < ALERT_COOLDOWN_MS) continue;
+
+    const failingSince = new Date(s.lastSuccessTime).toISOString();
+    const lastSuccess = new Date(s.lastSuccessTime).toISOString();
+    const msg = `ATIS Alert: ${icao} scraper failing since ${failingSince}. Last success: ${lastSuccess}. Error: ${s.lastError || 'Unknown'}`;
+
+    await sendTelegram(msg);
+    s.lastAlertTime = now;
+  }
+}
+
+// For testing
+function _reset() {
+  state.clear();
+}
+
+function _getState(icao) {
+  return state.get(icao);
+}
+
+module.exports = {
+  recordSuccess,
+  recordFailure,
+  checkAlerts,
+  ALERT_THRESHOLD_MS,
+  ALERT_COOLDOWN_MS,
+  _reset,
+  _getState,
+};

--- a/test-server.js
+++ b/test-server.js
@@ -1,0 +1,3 @@
+require('./src/data/aeroview').scrapeAeroview('CYPK')
+  .then(r => console.log(r ? r.letter + ': ' + r.raw.substring(0,80) : 'null'))
+  .catch(e => console.error('FAIL:', e.message));

--- a/test/alerter.test.js
+++ b/test/alerter.test.js
@@ -1,0 +1,104 @@
+const { describe, it, beforeEach, afterEach, mock } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  recordSuccess,
+  recordFailure,
+  checkAlerts,
+  ALERT_THRESHOLD_MS,
+  _reset,
+  _getState,
+} = require('../src/monitoring/alerter');
+
+describe('alerter', () => {
+  let fetchMock;
+
+  beforeEach(() => {
+    _reset();
+    process.env.TELEGRAM_BOT_TOKEN = 'test-token';
+    process.env.TELEGRAM_CHAT_ID = '12345';
+    fetchMock = mock.fn(() => Promise.resolve({ ok: true }));
+    globalThis.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    delete process.env.TELEGRAM_CHAT_ID;
+    mock.restoreAll();
+  });
+
+  it('fires alert after 30min threshold', async () => {
+    recordFailure('CYVR', 'timeout');
+    // Backdate lastSuccessTime to 31 minutes ago
+    const s = _getState('CYVR');
+    s.lastSuccessTime = Date.now() - ALERT_THRESHOLD_MS - 60_000;
+
+    await checkAlerts();
+
+    assert.equal(fetchMock.mock.calls.length, 1);
+    const [url, opts] = fetchMock.mock.calls[0].arguments;
+    assert.ok(url.includes('test-token'));
+    const body = JSON.parse(opts.body);
+    assert.equal(body.chat_id, '12345');
+    assert.ok(body.text.includes('CYVR'));
+    assert.ok(body.text.includes('timeout'));
+  });
+
+  it('does not alert before 30min threshold', async () => {
+    recordFailure('CYVR', 'timeout');
+    // lastSuccessTime is still recent (just initialized)
+    await checkAlerts();
+    assert.equal(fetchMock.mock.calls.length, 0);
+  });
+
+  it('does not send duplicate alerts within cooldown window', async () => {
+    recordFailure('CYVR', 'timeout');
+    const s = _getState('CYVR');
+    s.lastSuccessTime = Date.now() - ALERT_THRESHOLD_MS - 60_000;
+
+    await checkAlerts();
+    assert.equal(fetchMock.mock.calls.length, 1);
+
+    // Second check within cooldown - should not alert again
+    await checkAlerts();
+    assert.equal(fetchMock.mock.calls.length, 1);
+  });
+
+  it('clears alert state after success', async () => {
+    recordFailure('CYVR', 'timeout');
+    const s = _getState('CYVR');
+    s.lastSuccessTime = Date.now() - ALERT_THRESHOLD_MS - 60_000;
+
+    await checkAlerts();
+    assert.equal(fetchMock.mock.calls.length, 1);
+
+    // Airport recovers
+    recordSuccess('CYVR');
+    const updated = _getState('CYVR');
+    assert.equal(updated.consecutiveFailures, 0);
+    assert.equal(updated.lastAlertTime, null);
+
+    // Should not alert after recovery
+    await checkAlerts();
+    assert.equal(fetchMock.mock.calls.length, 1);
+  });
+
+  it('tracks consecutive failures', () => {
+    recordFailure('CYVR', 'err1');
+    recordFailure('CYVR', 'err2');
+    recordFailure('CYVR', 'err3');
+    assert.equal(_getState('CYVR').consecutiveFailures, 3);
+    assert.equal(_getState('CYVR').lastError, 'err3');
+  });
+
+  it('skips sending when env vars are missing', async () => {
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    delete process.env.TELEGRAM_CHAT_ID;
+
+    recordFailure('CYVR', 'timeout');
+    const s = _getState('CYVR');
+    s.lastSuccessTime = Date.now() - ALERT_THRESHOLD_MS - 60_000;
+
+    await checkAlerts();
+    assert.equal(fetchMock.mock.calls.length, 0);
+  });
+});


### PR DESCRIPTION
Alerts Steve via Telegram if any airport scraper fails for >30 min. Tracks per-airport failures, dedupes alerts to once per 30min window. Env vars: TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID.