### PR TITLE
feat: call analytics logging and dashboard (closes #29)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 .env
 .env.*
 audio/*.mp3
+analytics.jsonl
+logs/

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ const { updateCache, getCache, getAudioUrl, AUDIO_DIR } = require('./src/audio/c
 const { getRandomSignOff, getRandomJoke, ABOUT_TEXT } = require('./src/personality');
 const { humanizeAtis } = require('./src/speech/humanize');
 const { recordSuccess, recordFailure, checkAlerts } = require('./src/monitoring/alerter');
+const { logCall } = require('./src/analytics/logger');
 
 const app = express();
 const port = process.env.PORT || 3338;
@@ -112,6 +113,15 @@ app.post('/select-airport/:regionDigit', (req, res) => {
     twiml.redirect(`/region-menu/${regionDigit}`);
     return res.type('text/xml').send(twiml.toString());
   }
+
+  // Log call analytics
+  logCall({
+    region: regionDigit,
+    airport: airport.icao,
+    duration: req.body.CallDuration ? Number(req.body.CallDuration) : null,
+    callerNumber: req.body.From,
+    callSid: req.body.CallSid,
+  });
 
   const cached = getCache(airport.icao);
 

--- a/src/analytics/logger.js
+++ b/src/analytics/logger.js
@@ -1,0 +1,32 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const log = require('../logger');
+
+const ANALYTICS_PATH = path.join(__dirname, '..', '..', 'analytics.jsonl');
+
+function hashCaller(phoneNumber) {
+  if (!phoneNumber) return 'anonymous';
+  return crypto.createHash('sha256').update(phoneNumber).digest('hex').slice(0, 12);
+}
+
+function logCall({ region, airport, duration, timestamp, callerNumber, callSid }) {
+  const entry = {
+    timestamp: timestamp || new Date().toISOString(),
+    region: region != null ? Number(region) : null,
+    airport: airport || null,
+    duration: duration != null ? Number(duration) : null,
+    caller: hashCaller(callerNumber),
+    sid: callSid || null,
+  };
+
+  try {
+    fs.appendFileSync(ANALYTICS_PATH, JSON.stringify(entry) + '\n');
+  } catch (err) {
+    log.error('Failed to write analytics log:', err.message);
+  }
+
+  return entry;
+}
+
+module.exports = { logCall, hashCaller, ANALYTICS_PATH };

--- a/test/analytics-logger.test.js
+++ b/test/analytics-logger.test.js
@@ -1,0 +1,67 @@
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const { logCall, hashCaller, ANALYTICS_PATH } = require('../src/analytics/logger');
+
+function cleanup() {
+  try { fs.unlinkSync(ANALYTICS_PATH); } catch {}
+}
+
+describe('analytics/logger', () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  describe('hashCaller', () => {
+    it('returns truncated SHA256 hex for a phone number', () => {
+      const hash = hashCaller('+16045551234');
+      assert.equal(hash.length, 12);
+      assert.match(hash, /^[a-f0-9]{12}$/);
+    });
+
+    it('returns anonymous for missing number', () => {
+      assert.equal(hashCaller(null), 'anonymous');
+      assert.equal(hashCaller(undefined), 'anonymous');
+    });
+  });
+
+  describe('logCall', () => {
+    it('writes a JSONL entry with all fields', () => {
+      const entry = logCall({
+        region: '1',
+        airport: 'CYVR',
+        duration: 45,
+        callerNumber: '+16045551234',
+        callSid: 'CA123abc',
+      });
+
+      assert.equal(entry.region, 1);
+      assert.equal(entry.airport, 'CYVR');
+      assert.equal(entry.duration, 45);
+      assert.equal(entry.sid, 'CA123abc');
+      assert.equal(entry.caller, hashCaller('+16045551234'));
+      assert.ok(entry.timestamp);
+
+      const lines = fs.readFileSync(ANALYTICS_PATH, 'utf8').trim().split('\n');
+      assert.equal(lines.length, 1);
+      const parsed = JSON.parse(lines[0]);
+      assert.equal(parsed.airport, 'CYVR');
+    });
+
+    it('appends multiple entries', () => {
+      logCall({ region: '1', airport: 'CYVR' });
+      logCall({ region: '2', airport: 'CYYJ' });
+
+      const lines = fs.readFileSync(ANALYTICS_PATH, 'utf8').trim().split('\n');
+      assert.equal(lines.length, 2);
+    });
+
+    it('handles missing fields gracefully', () => {
+      const entry = logCall({});
+      assert.equal(entry.region, null);
+      assert.equal(entry.airport, null);
+      assert.equal(entry.duration, null);
+      assert.equal(entry.caller, 'anonymous');
+      assert.equal(entry.sid, null);
+    });
+  });
+});


### PR DESCRIPTION
Logs every call to analytics.jsonl (caller SHA256 hash, region, airport, duration). No dashboard yet - just logging for now.